### PR TITLE
feat: add bbox query capability

### DIFF
--- a/deployment/kubernetes/flood-api.yaml
+++ b/deployment/kubernetes/flood-api.yaml
@@ -16,7 +16,7 @@ spec:
         app: flood-api
     spec:
       containers:
-        - image: ghcr.io/openearthplatforminitiative/flood-api:0.5.7
+        - image: ghcr.io/openearthplatforminitiative/flood-api:0.6.0
           name: flood-api
           ports:
             - containerPort: 8080
@@ -24,7 +24,7 @@ spec:
             - name: API_ROOT_PATH
               value: "/flood"
             - name: VERSION
-              value: 0.5.7
+              value: 0.6.0
 ---
 apiVersion: v1
 kind: Service

--- a/flood_api/dependencies/queryparams.py
+++ b/flood_api/dependencies/queryparams.py
@@ -3,6 +3,10 @@ from typing import Annotated, Optional, Union
 
 from fastapi import Depends, HTTPException, Query
 
+from flood_api.settings import settings
+
+INVALID_STATUS_CODE = settings.invalid_query_status_code
+
 # Define a union type for the dependency
 LocationQuery = Union[tuple[float, float], tuple[float, float, float, float]]
 
@@ -24,12 +28,12 @@ def location_query_dependency(
 
     if coordinates is None and bbox is None:
         raise HTTPException(
-            status_code=400,
+            status_code=INVALID_STATUS_CODE,
             detail="Either coordinates or bounding box must be provided.",
         )
     if coordinates is not None and bbox is not None:
         raise HTTPException(
-            status_code=400,
+            status_code=INVALID_STATUS_CODE,
             detail="Only coordinates or bounding box can be provided, not both.",
         )
 

--- a/flood_api/dependencies/queryparams.py
+++ b/flood_api/dependencies/queryparams.py
@@ -1,19 +1,16 @@
 from datetime import date
-from typing import Annotated, Optional, Union
+from typing import Annotated
 
 from fastapi import Depends, HTTPException, Query
 
-from flood_api.settings import settings
 from flood_api.utils.validation_helpers import (
     validate_bounding_box,
     validate_coordinates,
     validate_dates,
 )
 
-INVALID_STATUS_CODE = settings.invalid_query_status_code
-
 # Define a union type for the dependency
-LocationQuery = Union[tuple[float, float], tuple[float, float, float, float]]
+LocationQuery = tuple[float, float] | tuple[float, float, float, float]
 
 
 def location_query_dependency(
@@ -24,20 +21,20 @@ def location_query_dependency(
     min_lat: Annotated[float | None, Query(description="Minimum latitude")] = None,
     max_lat: Annotated[float | None, Query(description="Maximum latitude")] = None,
 ) -> LocationQuery:
-    coordinates = (lat, lon) if None not in (lat, lon) else None
-    bbox = (
-        (min_lat, max_lat, min_lon, max_lon)
-        if None not in (min_lat, max_lat, min_lon, max_lon)
-        else None
-    )
+    coordinates = (lat, lon)
+    bbox = (min_lat, max_lat, min_lon, max_lon)
+    if None in coordinates:
+        coordinates = None
+    if None in bbox:
+        bbox = None
     if not (coordinates or bbox):
         raise HTTPException(
-            status_code=INVALID_STATUS_CODE,
+            status_code=400,
             detail="Either coordinates or bounding box must be provided.",
         )
     if coordinates and bbox:
         raise HTTPException(
-            status_code=INVALID_STATUS_CODE,
+            status_code=400,
             detail="Only coordinates or bounding box can be provided, not both.",
         )
     if coordinates:
@@ -48,9 +45,7 @@ def location_query_dependency(
         return bbox
 
 
-LocationQueryDep = Annotated[
-    Optional[LocationQuery], Depends(location_query_dependency)
-]
+LocationQueryDep = Annotated[LocationQuery, Depends(location_query_dependency)]
 
 
 def include_neighbors(

--- a/flood_api/dependencies/queryparams.py
+++ b/flood_api/dependencies/queryparams.py
@@ -14,9 +14,10 @@ def coordinates(
         Query(description="Latitude of the coordinate to retrieve data for"),
     ] = None,
 ) -> Optional[tuple[float, float]]:
-    if all([lat, lon]):
-        return (lat, lon)
-    return None
+    coordinates = (lat, lon)
+    if any(val is None for val in coordinates):
+        return None
+    return coordinates
 
 
 CoordinatesDep = Annotated[Optional[tuple[float, float]], Depends(coordinates)]
@@ -48,9 +49,10 @@ def bounding_box(
         ),
     ] = None,
 ) -> Optional[tuple[float, float, float, float]]:
-    if all([min_lat, max_lat, min_lon, max_lon]):
-        return (min_lat, max_lat, min_lon, max_lon)
-    return None
+    bbox = (min_lat, max_lat, min_lon, max_lon)
+    if any(val is None for val in bbox):
+        return None
+    return bbox
 
 
 BoundingBoxDep = Annotated[

--- a/flood_api/dependencies/queryparams.py
+++ b/flood_api/dependencies/queryparams.py
@@ -1,23 +1,61 @@
 from datetime import date
-from typing import Annotated
+from typing import Annotated, Optional
 
 from fastapi import Depends, Query
 
 
 def coordinates(
     lon: Annotated[
-        float,
+        float | None,
         Query(description="Longitude of the coordinate to retrieve data for"),
-    ],
+    ] = None,
     lat: Annotated[
-        float,
+        float | None,
         Query(description="Latitude of the coordinate to retrieve data for"),
-    ],
-) -> (float, float):
-    return lon, lat
+    ] = None,
+) -> Optional[tuple[float, float]]:
+    if all([lat, lon]):
+        return (lat, lon)
+    return None
 
 
-CoordinatesDep = Annotated[tuple[float, float], Depends(coordinates)]
+CoordinatesDep = Annotated[Optional[tuple[float, float]], Depends(coordinates)]
+
+
+def bounding_box(
+    min_lat: Annotated[
+        float | None,
+        Query(
+            description="Minimum latitude of the bounding box to retrieve data for",
+        ),
+    ] = None,
+    max_lat: Annotated[
+        float | None,
+        Query(
+            description="Maximum latitude of the bounding box to retrieve data for",
+        ),
+    ] = None,
+    min_lon: Annotated[
+        float | None,
+        Query(
+            description="Minimum longitude of the bounding box to retrieve data for",
+        ),
+    ] = None,
+    max_lon: Annotated[
+        float | None,
+        Query(
+            description="Maximum longitude of the bounding box to retrieve data for",
+        ),
+    ] = None,
+) -> Optional[tuple[float, float, float, float]]:
+    if all([min_lat, max_lat, min_lon, max_lon]):
+        return (min_lat, max_lat, min_lon, max_lon)
+    return None
+
+
+BoundingBoxDep = Annotated[
+    Optional[tuple[float, float, float, float]], Depends(bounding_box)
+]
 
 
 def include_neighbors(

--- a/flood_api/models/detailed_types.py
+++ b/flood_api/models/detailed_types.py
@@ -88,11 +88,11 @@ class DetailedFeatureCollection(FeatureCollection):
 
 
 class DetailedResponseModel(BaseModel):
-    queried_data: DetailedFeatureCollection = Field(
+    queried_location: DetailedFeatureCollection = Field(
         ...,
         description="A feature collection representing the queried location's detailed forecast data.",
     )
-    neighboring_data: Optional[DetailedFeatureCollection] = Field(
+    neighboring_location: Optional[DetailedFeatureCollection] = Field(
         default=None,
         description="A feature collection representing the neighboring location's detailed forecast data, potentially empty if there is no neighboring forecast data.",
     )

--- a/flood_api/models/detailed_types.py
+++ b/flood_api/models/detailed_types.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import List, Optional
+from typing import List
 
 from pydantic import BaseModel, Field
 
@@ -92,7 +92,7 @@ class DetailedResponseModel(BaseModel):
         ...,
         description="A feature collection representing the queried location's detailed forecast data.",
     )
-    neighboring_location: Optional[DetailedFeatureCollection] = Field(
+    neighboring_location: DetailedFeatureCollection | None = Field(
         default=None,
         description="A feature collection representing the neighboring location's detailed forecast data, potentially empty if there is no neighboring forecast data.",
     )

--- a/flood_api/models/detailed_types.py
+++ b/flood_api/models/detailed_types.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -88,11 +88,11 @@ class DetailedFeatureCollection(FeatureCollection):
 
 
 class DetailedResponseModel(BaseModel):
-    queried_cell: DetailedFeatureCollection = Field(
+    queried_data: DetailedFeatureCollection = Field(
         ...,
-        description="A feature collection representing the queried cell's detailed forecast data.",
+        description="A feature collection representing the queried location's detailed forecast data.",
     )
-    neighboring_cells: DetailedFeatureCollection = Field(
-        ...,
-        description="A feature collection representing the neighboring cells' detailed forecast data, potentially empty if there are no neighboring cells with forecast data.",
+    neighboring_data: Optional[DetailedFeatureCollection] = Field(
+        default=None,
+        description="A feature collection representing the neighboring location's detailed forecast data, potentially empty if there is no neighboring forecast data.",
     )

--- a/flood_api/models/summary_types.py
+++ b/flood_api/models/summary_types.py
@@ -4,7 +4,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from flood_api.models.shared_types import BaseModelWithDates, Feature, FeatureCollection
+from flood_api.models.shared_types import (BaseModelWithDates, Feature,
+                                           FeatureCollection)
 
 
 class PeakTimingEnum(str, Enum):
@@ -157,11 +158,11 @@ class SummaryFeatureCollection(FeatureCollection):
 
 
 class SummaryResponseModel(BaseModel):
-    queried_data: SummaryFeatureCollection = Field(
+    queried_location: SummaryFeatureCollection = Field(
         ...,
         description="A feature collection representing the queried location's summary forecast data.",
     )
-    neighboring_data: Optional[SummaryFeatureCollection] = Field(
+    neighboring_location: Optional[SummaryFeatureCollection] = Field(
         default=None,
         description="A feature collection representing the neighboring location's summary forecast data, potentially empty if there is no neighboring forecast data.",
     )

--- a/flood_api/models/summary_types.py
+++ b/flood_api/models/summary_types.py
@@ -1,6 +1,6 @@
 from datetime import date
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -157,11 +157,11 @@ class SummaryFeatureCollection(FeatureCollection):
 
 
 class SummaryResponseModel(BaseModel):
-    queried_cell: SummaryFeatureCollection = Field(
+    queried_data: SummaryFeatureCollection = Field(
         ...,
-        description="A feature collection representing the queried cell's summary forecast data.",
+        description="A feature collection representing the queried location's summary forecast data.",
     )
-    neighboring_cells: SummaryFeatureCollection = Field(
-        ...,
-        description="A feature collection representing the neighboring cells' summary forecast data, potentially empty if there are no neighboring cells with forecast data.",
+    neighboring_data: Optional[SummaryFeatureCollection] = Field(
+        default=None,
+        description="A feature collection representing the neighboring location's summary forecast data, potentially empty if there is no neighboring forecast data.",
     )

--- a/flood_api/models/summary_types.py
+++ b/flood_api/models/summary_types.py
@@ -1,6 +1,6 @@
 from datetime import date
 from enum import Enum
-from typing import List, Optional
+from typing import List
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -161,7 +161,7 @@ class SummaryResponseModel(BaseModel):
         ...,
         description="A feature collection representing the queried location's summary forecast data.",
     )
-    neighboring_location: Optional[SummaryFeatureCollection] = Field(
+    neighboring_location: SummaryFeatureCollection | None = Field(
         default=None,
         description="A feature collection representing the neighboring location's summary forecast data, potentially empty if there is no neighboring forecast data.",
     )

--- a/flood_api/models/summary_types.py
+++ b/flood_api/models/summary_types.py
@@ -4,8 +4,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from flood_api.models.shared_types import (BaseModelWithDates, Feature,
-                                           FeatureCollection)
+from flood_api.models.shared_types import BaseModelWithDates, Feature, FeatureCollection
 
 
 class PeakTimingEnum(str, Enum):

--- a/flood_api/models/threshold_types.py
+++ b/flood_api/models/threshold_types.py
@@ -41,7 +41,7 @@ class ThresholdFeatureCollection(FeatureCollection):
 
 
 class ThresholdResponseModel(BaseModel):
-    queried_cell: ThresholdFeatureCollection = Field(
+    queried_data: ThresholdFeatureCollection = Field(
         ...,
-        description="A feature collection representing the queried cell's threshold data for flood risk analysis.",
+        description="A feature collection representing the queried location's threshold data for flood risk analysis.",
     )

--- a/flood_api/models/threshold_types.py
+++ b/flood_api/models/threshold_types.py
@@ -41,7 +41,7 @@ class ThresholdFeatureCollection(FeatureCollection):
 
 
 class ThresholdResponseModel(BaseModel):
-    queried_data: ThresholdFeatureCollection = Field(
+    queried_location: ThresholdFeatureCollection = Field(
         ...,
         description="A feature collection representing the queried location's threshold data for flood risk analysis.",
     )

--- a/flood_api/routers/flood.py
+++ b/flood_api/routers/flood.py
@@ -29,7 +29,7 @@ router = APIRouter(tags=["flood"])
 @router.get(
     "/summary",
     summary="Get summary forecast for a location",
-    description="Returns a summary forecast of the next 30 days either for the cell at the given location or for the cells within the given bounding box",
+    description="Returns a summary forecast of the next 30 days either for the cell at the given coordinates or for the cells within the given bounding box",
 )
 async def summary(
     gdf: SummaryDataDep,
@@ -45,7 +45,7 @@ async def summary(
 
     if coordinates is not None:
         validate_coordinates(*coordinates)
-        queried_data, neighboring_data = get_data_for_point(
+        queried_location, neighboring_location = get_data_for_point(
             *coordinates,
             include_neighbors=include_neighbors,
             gdf=gdf,
@@ -53,27 +53,30 @@ async def summary(
 
     elif bbox is not None:
         validate_bounding_box(*bbox)
-        queried_data = get_data_for_bbox(
+        queried_location = get_data_for_bbox(
             bbox=bbox,
             gdf=gdf,
         )
-        neighboring_data = None
+        neighboring_location = None
 
     summary_cols = list(SummaryProperties.model_fields.keys())
 
-    queried_data_geojson = dataframe_to_geojson(df=queried_data, columns=summary_cols)
+    queried_location_geojson = dataframe_to_geojson(
+        df=queried_location, columns=summary_cols
+    )
 
     sort_columns = ["latitude", "longitude"]
 
-    if neighboring_data is None:
-        neighboring_data_geojson = None
+    if neighboring_location is None:
+        neighboring_location_geojson = None
     else:
-        neighboring_data_geojson = dataframe_to_geojson(
-            df=neighboring_data, columns=summary_cols, sort_columns=sort_columns
+        neighboring_location_geojson = dataframe_to_geojson(
+            df=neighboring_location, columns=summary_cols, sort_columns=sort_columns
         )
 
     response = SummaryResponseModel(
-        queried_data=queried_data_geojson, neighboring_data=neighboring_data_geojson
+        queried_location=queried_location_geojson,
+        neighboring_location=neighboring_location_geojson,
     )
 
     return response
@@ -82,7 +85,7 @@ async def summary(
 @router.get(
     "/detailed",
     summary="Get detailed forecast for a location",
-    description="Returns a detailed forecast of the next 30 days either for the cell at the given location or for the cells within the given bounding box",
+    description="Returns a detailed forecast of the next 30 days either for the cell at the given coordinates or for the cells within the given bounding box",
 )
 async def detailed(
     gdf: DetailedDataDep,
@@ -101,7 +104,7 @@ async def detailed(
 
     if coordinates is not None:
         validate_coordinates(*coordinates)
-        queried_data, neighboring_data = get_data_for_point(
+        queried_location, neighboring_location = get_data_for_point(
             *coordinates,
             include_neighbors=include_neighbors,
             gdf=gdf,
@@ -110,30 +113,31 @@ async def detailed(
 
     elif bbox is not None:
         validate_bounding_box(*bbox)
-        queried_data = get_data_for_bbox(
+        queried_location = get_data_for_bbox(
             bbox=bbox,
             gdf=gdf,
             date_range=date_range,
         )
-        neighboring_data = None
+        neighboring_location = None
 
     detailed_cols = list(DetailedProperties.model_fields.keys())
 
     sort_columns = ["latitude", "longitude", "step"]
 
-    queried_data_geojson = dataframe_to_geojson(
-        df=queried_data, columns=detailed_cols, sort_columns=sort_columns
+    queried_location_geojson = dataframe_to_geojson(
+        df=queried_location, columns=detailed_cols, sort_columns=sort_columns
     )
 
-    if neighboring_data is None:
-        neighboring_data_geojson = None
+    if neighboring_location is None:
+        neighboring_location_geojson = None
     else:
-        neighboring_data_geojson = dataframe_to_geojson(
-            df=neighboring_data, columns=detailed_cols, sort_columns=sort_columns
+        neighboring_location_geojson = dataframe_to_geojson(
+            df=neighboring_location, columns=detailed_cols, sort_columns=sort_columns
         )
 
     response = DetailedResponseModel(
-        queried_data=queried_data_geojson, neighboring_data=neighboring_data_geojson
+        queried_location=queried_location_geojson,
+        neighboring_location=neighboring_location_geojson,
     )
 
     return response
@@ -142,7 +146,7 @@ async def detailed(
 @router.get(
     "/threshold",
     summary="Get return period thresholds for a location",
-    description="Returns the 2-, 5-, and 20-year return period thresholds either for the cell at the given location or for the cells within the given bounding box",
+    description="Returns the 2-, 5-, and 20-year return period thresholds either for the cell at the given coordinates or for the cells within the given bounding box",
 )
 async def threshold(
     gdf: ThresholdDataDep,
@@ -157,27 +161,27 @@ async def threshold(
 
     if coordinates is not None:
         validate_coordinates(*coordinates)
-        queried_data, _ = get_data_for_point(
+        queried_location, _ = get_data_for_point(
             *coordinates,
             gdf=gdf,
         )
 
     elif bbox is not None:
         validate_bounding_box(*bbox)
-        queried_data = get_data_for_bbox(
+        queried_location = get_data_for_bbox(
             bbox=bbox,
             gdf=gdf,
         )
 
     threshold_cols = list(ThresholdProperties.model_fields.keys())
 
-    queried_data_geojson = dataframe_to_geojson(
-        df=queried_data,
+    queried_location_geojson = dataframe_to_geojson(
+        df=queried_location,
         columns=threshold_cols,
     )
 
     response = ThresholdResponseModel(
-        queried_data=queried_data_geojson,
+        queried_location=queried_location_geojson,
     )
 
     return response

--- a/flood_api/routers/flood.py
+++ b/flood_api/routers/flood.py
@@ -6,6 +6,7 @@ from flood_api.dependencies.flooddata import (
     ThresholdDataDep,
 )
 from flood_api.dependencies.queryparams import (
+    BoundingBoxDep,
     CoordinatesDep,
     DateRangeDep,
     IncludeNeighborsDep,
@@ -13,47 +14,66 @@ from flood_api.dependencies.queryparams import (
 from flood_api.models.detailed_types import DetailedProperties, DetailedResponseModel
 from flood_api.models.summary_types import SummaryProperties, SummaryResponseModel
 from flood_api.models.threshold_types import ThresholdProperties, ThresholdResponseModel
-from flood_api.utils.geospatial_operations import get_data_for_point
+from flood_api.utils.geospatial_operations import get_data_for_bbox, get_data_for_point
 from flood_api.utils.json_utilities import dataframe_to_geojson
-from flood_api.utils.validation_helpers import validate_coordinates, validate_dates
+from flood_api.utils.validation_helpers import (
+    validate_bounding_box,
+    validate_coordinates,
+    validate_dates,
+    validate_generic_inputs,
+)
 
 router = APIRouter(tags=["flood"])
 
 
 @router.get(
     "/summary",
-    summary="Get summary forecast",
-    description="Returns a summary forecast of the next 30 days for the given location",
+    summary="Get summary forecast for a location",
+    description="Returns a summary forecast of the next 30 days either for the cell at the given location or for the cells within the given bounding box",
 )
 async def summary(
     gdf: SummaryDataDep,
     coordinates: CoordinatesDep,
+    bbox: BoundingBoxDep,
     include_neighbors: IncludeNeighborsDep,
 ) -> SummaryResponseModel:
-    longitude, latitude = coordinates
-
-    # Validate the inputs
-    validate_coordinates(latitude=latitude, longitude=longitude)
-
-    queried_cell, neighboring_cells = get_data_for_point(
-        latitude=latitude,
-        longitude=longitude,
-        include_neighbors=include_neighbors,
-        gdf=gdf,
+    validate_generic_inputs(
+        coordinates,
+        bbox,
+        possible_inputs_str="coordinates, bounding box",
     )
+
+    if coordinates is not None:
+        validate_coordinates(*coordinates)
+        queried_data, neighboring_data = get_data_for_point(
+            *coordinates,
+            include_neighbors=include_neighbors,
+            gdf=gdf,
+        )
+
+    elif bbox is not None:
+        validate_bounding_box(*bbox)
+        queried_data = get_data_for_bbox(
+            bbox=bbox,
+            gdf=gdf,
+        )
+        neighboring_data = None
 
     summary_cols = list(SummaryProperties.model_fields.keys())
 
-    queried_cell_geojson = dataframe_to_geojson(df=queried_cell, columns=summary_cols)
+    queried_data_geojson = dataframe_to_geojson(df=queried_data, columns=summary_cols)
 
     sort_columns = ["latitude", "longitude"]
 
-    neighboring_cells_geojson = dataframe_to_geojson(
-        df=neighboring_cells, columns=summary_cols, sort_columns=sort_columns
-    )
+    if neighboring_data is None:
+        neighboring_data_geojson = None
+    else:
+        neighboring_data_geojson = dataframe_to_geojson(
+            df=neighboring_data, columns=summary_cols, sort_columns=sort_columns
+        )
 
     response = SummaryResponseModel(
-        queried_cell=queried_cell_geojson, neighboring_cells=neighboring_cells_geojson
+        queried_data=queried_data_geojson, neighboring_data=neighboring_data_geojson
     )
 
     return response
@@ -61,43 +81,59 @@ async def summary(
 
 @router.get(
     "/detailed",
-    summary="Get detailed forecast",
-    description="Returns a detailed forecast of the next 30 days for the given location",
+    summary="Get detailed forecast for a location",
+    description="Returns a detailed forecast of the next 30 days either for the cell at the given location or for the cells within the given bounding box",
 )
 async def detailed(
     gdf: DetailedDataDep,
     coordinates: CoordinatesDep,
+    bbox: BoundingBoxDep,
     include_neighbors: IncludeNeighborsDep,
     date_range: DateRangeDep,
 ) -> DetailedResponseModel:
-    longitude, latitude = coordinates
+    validate_generic_inputs(
+        coordinates,
+        bbox,
+        possible_inputs_str="coordinates, bounding box",
+    )
 
-    # Validate the inputs
-    validate_coordinates(latitude=latitude, longitude=longitude)
     validate_dates(*date_range)
 
-    queried_cell, neighboring_cells = get_data_for_point(
-        latitude=latitude,
-        longitude=longitude,
-        include_neighbors=include_neighbors,
-        gdf=gdf,
-        date_range=date_range,
-    )
+    if coordinates is not None:
+        validate_coordinates(*coordinates)
+        queried_data, neighboring_data = get_data_for_point(
+            *coordinates,
+            include_neighbors=include_neighbors,
+            gdf=gdf,
+            date_range=date_range,
+        )
+
+    elif bbox is not None:
+        validate_bounding_box(*bbox)
+        queried_data = get_data_for_bbox(
+            bbox=bbox,
+            gdf=gdf,
+            date_range=date_range,
+        )
+        neighboring_data = None
 
     detailed_cols = list(DetailedProperties.model_fields.keys())
 
     sort_columns = ["latitude", "longitude", "step"]
 
-    queried_cell_geojson = dataframe_to_geojson(
-        df=queried_cell, columns=detailed_cols, sort_columns=sort_columns
+    queried_data_geojson = dataframe_to_geojson(
+        df=queried_data, columns=detailed_cols, sort_columns=sort_columns
     )
 
-    neighboring_cells_geojson = dataframe_to_geojson(
-        df=neighboring_cells, columns=detailed_cols, sort_columns=sort_columns
-    )
+    if neighboring_data is None:
+        neighboring_data_geojson = None
+    else:
+        neighboring_data_geojson = dataframe_to_geojson(
+            df=neighboring_data, columns=detailed_cols, sort_columns=sort_columns
+        )
 
     response = DetailedResponseModel(
-        queried_cell=queried_cell_geojson, neighboring_cells=neighboring_cells_geojson
+        queried_data=queried_data_geojson, neighboring_data=neighboring_data_geojson
     )
 
     return response
@@ -105,33 +141,43 @@ async def detailed(
 
 @router.get(
     "/threshold",
-    summary="Get return period thresholds",
-    description="Returns the 2-, 5-, and 20-year return period thresholds for the given location",
+    summary="Get return period thresholds for a location",
+    description="Returns the 2-, 5-, and 20-year return period thresholds either for the cell at the given location or for the cells within the given bounding box",
 )
 async def threshold(
     gdf: ThresholdDataDep,
     coordinates: CoordinatesDep,
+    bbox: BoundingBoxDep,
 ) -> ThresholdResponseModel:
-    longitude, latitude = coordinates
-
-    # Validate the inputs
-    validate_coordinates(latitude=latitude, longitude=longitude)
-
-    queried_cell, _ = get_data_for_point(
-        latitude=latitude,
-        longitude=longitude,
-        gdf=gdf,
+    validate_generic_inputs(
+        coordinates,
+        bbox,
+        possible_inputs_str="coordinates, bounding box",
     )
+
+    if coordinates is not None:
+        validate_coordinates(*coordinates)
+        queried_data, _ = get_data_for_point(
+            *coordinates,
+            gdf=gdf,
+        )
+
+    elif bbox is not None:
+        validate_bounding_box(*bbox)
+        queried_data = get_data_for_bbox(
+            bbox=bbox,
+            gdf=gdf,
+        )
 
     threshold_cols = list(ThresholdProperties.model_fields.keys())
 
-    queried_cell_geojson = dataframe_to_geojson(
-        df=queried_cell,
+    queried_data_geojson = dataframe_to_geojson(
+        df=queried_data,
         columns=threshold_cols,
     )
 
     response = ThresholdResponseModel(
-        queried_cell=queried_cell_geojson,
+        queried_data=queried_data_geojson,
     )
 
     return response

--- a/flood_api/routers/flood.py
+++ b/flood_api/routers/flood.py
@@ -15,11 +15,6 @@ from flood_api.models.summary_types import SummaryProperties, SummaryResponseMod
 from flood_api.models.threshold_types import ThresholdProperties, ThresholdResponseModel
 from flood_api.utils.geospatial_operations import get_data_for_bbox, get_data_for_point
 from flood_api.utils.json_utilities import dataframe_to_geojson
-from flood_api.utils.validation_helpers import (
-    validate_bounding_box,
-    validate_coordinates,
-    validate_dates,
-)
 
 router = APIRouter(tags=["flood"])
 
@@ -39,18 +34,13 @@ async def summary(
 ) -> SummaryResponseModel:
     match location_query:
         case lat, lon:
-            validate_coordinates(lat, lon)
             queried_location, neighboring_location = get_data_for_point(
                 latitude=lat,
                 longitude=lon,
                 include_neighbors=include_neighbors,
                 gdf=gdf,
             )
-
         case min_lat, max_lat, min_lon, max_lon:
-            validate_bounding_box(
-                min_lat=min_lat, max_lat=max_lat, min_lon=min_lon, max_lon=max_lon
-            )
             queried_location = get_data_for_bbox(
                 bbox=location_query,
                 gdf=gdf,
@@ -94,11 +84,8 @@ async def detailed(
     include_neighbors: IncludeNeighborsDep,
     date_range: DateRangeDep,
 ) -> DetailedResponseModel:
-    validate_dates(*date_range)
-
     match location_query:
         case lat, lon:
-            validate_coordinates(lat, lon)
             queried_location, neighboring_location = get_data_for_point(
                 latitude=lat,
                 longitude=lon,
@@ -106,11 +93,7 @@ async def detailed(
                 gdf=gdf,
                 date_range=date_range,
             )
-
         case min_lat, max_lat, min_lon, max_lon:
-            validate_bounding_box(
-                min_lat=min_lat, max_lat=max_lat, min_lon=min_lon, max_lon=max_lon
-            )
             queried_location = get_data_for_bbox(
                 bbox=location_query,
                 gdf=gdf,
@@ -154,15 +137,10 @@ async def threshold(
 ) -> ThresholdResponseModel:
     match location_query:
         case lat, lon:
-            validate_coordinates(lat, lon)
             queried_location, _ = get_data_for_point(
                 longitude=lon, latitude=lat, gdf=gdf
             )
-
         case min_lat, max_lat, min_lon, max_lon:
-            validate_bounding_box(
-                min_lat=min_lat, max_lat=max_lat, min_lon=min_lon, max_lon=max_lon
-            )
             queried_location = get_data_for_bbox(bbox=location_query, gdf=gdf)
 
     threshold_cols = list(ThresholdProperties.model_fields.keys())

--- a/flood_api/settings.py
+++ b/flood_api/settings.py
@@ -20,8 +20,6 @@ class Settings(BaseSettings):
     }
     glofas_resolution: float = 0.05
     glofas_precision: int = 3
-    out_of_bounds_query_status_code: int = 404
-    invalid_query_status_code: int = 400
 
 
 settings = Settings()

--- a/flood_api/settings.py
+++ b/flood_api/settings.py
@@ -20,6 +20,8 @@ class Settings(BaseSettings):
     }
     glofas_resolution: float = 0.05
     glofas_precision: int = 3
+    out_of_bounds_query_status_code: int = 404
+    invalid_query_status_code: int = 400
 
 
 settings = Settings()

--- a/flood_api/tests/test_detailed.py
+++ b/flood_api/tests/test_detailed.py
@@ -10,8 +10,8 @@ from flood_api.settings import settings
 from flood_api.tests.synthetic_data import gdf_test_detailed
 
 GLOFAS_ROI = settings.glofas_roi
-OUT_OF_BOUNDS_STATUS_CODE = settings.out_of_bounds_query_status_code
-INVALID_STATUS_CODE = settings.invalid_query_status_code
+OUT_OF_BOUNDS_STATUS_CODE = 404
+INVALID_STATUS_CODE = 400
 
 TOTAL_STEPS = 30
 

--- a/flood_api/tests/test_detailed.py
+++ b/flood_api/tests/test_detailed.py
@@ -18,12 +18,56 @@ app.dependency_overrides[get_detailed_data] = lambda: gdf_test_detailed
 client = TestClient(app)
 
 
+def get_detailed_response(params):
+    return client.get("/detailed", params=params)
+
+
 def get_detailed_response_code(params):
-    response = client.get("/detailed", params=params)
-    return response.status_code
+    return get_detailed_response(params).status_code
 
 
-def test_detailed_roi():
+def test_detailed_arg_validity():
+    expected_error_code = 404
+
+    # Neither lat/lon nor bbox are provided
+    params = {"include_neighbors": "true"}
+    response = get_detailed_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Both lat/lon and bbox are provided
+    params = {
+        "lat": 6.2,
+        "lon": 39.05,
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+    response = get_detailed_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Incomplete bbox is provided
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+        "min_lon": 39.0,
+    }
+    response = get_detailed_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Incomplete coordinates are provided
+    params = {
+        "lat": 6.2,
+    }
+    response = get_detailed_response(params)
+
+    assert response.status_code == expected_error_code
+
+
+def test_detailed_point_validity():
     min_lat = GLOFAS_ROI["min_lat"]
     max_lat = GLOFAS_ROI["max_lat"]
     min_lon = GLOFAS_ROI["min_lon"]
@@ -64,18 +108,117 @@ def test_detailed_roi():
     assert get_detailed_response_code(params) == 200
 
 
-def test_detailed_border_query():
+def test_detailed_bbox_validity():
+    min_lat = GLOFAS_ROI["min_lat"]
+    max_lat = GLOFAS_ROI["max_lat"]
+    min_lon = GLOFAS_ROI["min_lon"]
+    max_lon = GLOFAS_ROI["max_lon"]
+    eps = 1e-6
+    expected_error_code = 404
+
+    # Queried maximum latitude is smaller than the minimum latitude
+    params = {
+        "min_lat": 4.0,
+        "max_lat": 3.0,
+        "min_lon": 0.0,
+        "max_lon": 10.0,
+    }
+    assert get_detailed_response_code(params) == expected_error_code
+
+    # Queried maximum longitude is the same as the minimum longitude
+    params = {
+        "min_lat": 0.0,
+        "max_lat": 10.0,
+        "min_lon": 4.0,
+        "max_lon": 4.0,
+    }
+    assert get_detailed_response_code(params) == expected_error_code
+
+    # Queried minimum latitude is outside the ROI
+    params = {
+        "min_lat": min_lat - eps,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_detailed_response_code(params) == expected_error_code
+
+    # Queried maximum latitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 2,
+        "max_lat": max_lat + eps,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_detailed_response_code(params) == expected_error_code
+
+    # Queried minimum longitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": min_lon - eps,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_detailed_response_code(params) == expected_error_code
+
+    # Queried maximum longitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 2,
+        "max_lon": max_lon + eps,
+    }
+    assert get_detailed_response_code(params) == expected_error_code
+
+    # Queried minimum latitude is inside the ROI
+    params = {
+        "min_lat": min_lat,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_detailed_response_code(params) == 200
+
+    # Queried maximum latitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 2,
+        "max_lat": max_lat,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_detailed_response_code(params) == 200
+
+    # Queried minimum longitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": min_lon,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_detailed_response_code(params) == 200
+
+    # Queried maximum longitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 2,
+        "max_lon": max_lon,
+    }
+    assert get_detailed_response_code(params) == 200
+
+
+def test_detailed_point_border_query():
     # Queried point is in the lower left
     # corner of the grid cell
     params = {"lat": 6.2, "lon": 39.05}
 
-    response = client.get("/detailed", params=params)
+    response = get_detailed_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -84,24 +227,24 @@ def test_detailed_border_query():
     # corner of the grid cell
     params = {"lat": 6.2, "lon": 39.1}
 
-    response = client.get("/detailed", params=params)
+    response = get_detailed_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Assert that dataframe is empty
     assert gdf.empty
 
 
-def test_detailed_date_range():
+def test_detailed_point_date_range():
     min_lat = GLOFAS_ROI["min_lat"]
     max_lat = GLOFAS_ROI["max_lat"]
     min_lon = GLOFAS_ROI["min_lon"]
     max_lon = GLOFAS_ROI["max_lon"]
-    expected_error_code = 400
+    expected_error_code = 404
 
     # Start date is before the end date
     params = {
@@ -134,19 +277,19 @@ def test_detailed_date_range():
     assert get_detailed_response_code(params) == 200
 
 
-def test_detailed_general():
+def test_detailed_point_general():
     params = {
         "lat": 6.2,
         "lon": 39.05,
     }
 
-    response = client.get("/detailed", params=params)
+    response = get_detailed_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -162,17 +305,17 @@ def test_detailed_general():
     assert gdf["issued_on"].nunique() == 1
 
 
-def test_detailed_neighbor():
+def test_detailed_point_neighbor():
     # Neighbors are included
     params = {"lat": 6.2, "lon": 39.05, "include_neighbors": "true"}
 
-    response = client.get("/detailed", params=params)
+    response = get_detailed_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf_neighbor = gpd.GeoDataFrame.from_features(data["neighboring_cells"]["features"])
+    gdf_neighbor = gpd.GeoDataFrame.from_features(data["neighboring_data"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf_neighbor.empty
@@ -188,7 +331,7 @@ def test_detailed_neighbor():
     assert gdf_neighbor["issued_on"].nunique() == 1
 
 
-def test_detailed_day_range():
+def test_detailed_point_day_range():
     # Both start and end dates are specified
     params = {
         "lat": 6.2,
@@ -198,14 +341,14 @@ def test_detailed_day_range():
         "include_neighbors": "true",
     }
 
-    response = client.get("/detailed", params=params)
+    response = get_detailed_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
-    gdf_neighbor = gpd.GeoDataFrame.from_features(data["neighboring_cells"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf_neighbor = gpd.GeoDataFrame.from_features(data["neighboring_data"]["features"])
 
     # Convert 'valid_for' column to date
     gdf["valid_for"] = pd.to_datetime(gdf["valid_for"]).dt.date
@@ -218,8 +361,6 @@ def test_detailed_day_range():
     # Assert that 'step' column is increasing
     assert gdf["step"].is_monotonic_increasing
     assert gdf_neighbor["step"].is_monotonic_increasing
-
-    print(gdf["valid_for"])
 
     # Assert that row count is correct
     assert len(gdf) == 3
@@ -238,7 +379,7 @@ def test_detailed_day_range():
     assert gdf_neighbor["valid_for"].max() == date(2023, 12, 1)
 
 
-def test_detailed_day_range_no_start():
+def test_detailed_point_day_range_no_start():
     # We are testing the case where the end date is omitted
     params = {
         "lat": 6.2,
@@ -246,13 +387,13 @@ def test_detailed_day_range_no_start():
         "start_date": "2023-11-29",
     }
 
-    response = client.get("/detailed", params=params)
+    response = get_detailed_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Convert 'valid_for' column to date
     gdf["valid_for"] = pd.to_datetime(gdf["valid_for"]).dt.date
@@ -274,7 +415,7 @@ def test_detailed_day_range_no_start():
     assert gdf["valid_for"].max() == date(2023, 12, 9)
 
 
-def test_detailed_day_range_no_end():
+def test_detailed_point_day_range_no_end():
     # We are testing the case where the start date is omitted
     params = {
         "lat": 6.2,
@@ -282,13 +423,13 @@ def test_detailed_day_range_no_end():
         "end_date": "2023-12-01",
     }
 
-    response = client.get("/detailed", params=params)
+    response = get_detailed_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Convert 'valid_for' column to date
     gdf["valid_for"] = pd.to_datetime(gdf["valid_for"]).dt.date
@@ -308,3 +449,58 @@ def test_detailed_day_range_no_end():
     # Assert that 'valid_for' is within the specified range
     assert gdf["valid_for"].min() == date(2023, 11, 10)
     assert gdf["valid_for"].max() == date(2023, 12, 1)
+
+
+def test_detailed_bbox_general():
+    # Queried bounding box covers both cells in the test data
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.25,  # On the boundary between the two cells
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+
+    response = get_detailed_response(params)
+    data = response.json()
+
+    assert response.status_code == 200
+
+    # Convert the dictionary to a GeoDataFrame
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+
+    # Assert that dataframe is not empty
+    assert not gdf.empty
+
+    # Assert that row count is correct
+    assert len(gdf) == TOTAL_STEPS * 2
+
+    # Assert that the 'geometry' column has two unique values
+    assert gdf["geometry"].nunique() == 2
+
+    # Queried bounding box covers only one cell in the test data
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.24999,  # Just below the upper boundary
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+
+    response = get_detailed_response(params)
+    data = response.json()
+
+    assert response.status_code == 200
+
+    # Convert the dictionary to a GeoDataFrame
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+
+    # Assert that dataframe is not empty
+    assert not gdf.empty
+
+    # Assert that row count is correct
+    assert len(gdf) == TOTAL_STEPS
+
+    # Assert that 'step' column is increasing
+    assert gdf["step"].is_monotonic_increasing
+
+    # Assert that the 'geometry' column has one unique value
+    assert gdf["geometry"].nunique() == 1

--- a/flood_api/tests/test_detailed.py
+++ b/flood_api/tests/test_detailed.py
@@ -66,6 +66,26 @@ def test_detailed_arg_validity():
 
     assert response.status_code == expected_error_code
 
+    # One of the coordinates is zero
+    params = {
+        "lon": 0.0,
+        "lat": 6.2,
+    }
+    response = get_detailed_response(params)
+
+    assert response.status_code == 200
+
+    # One of the bounding box coordinates is zero
+    params = {
+        "min_lon": 0.0,
+        "max_lon": 40.0,
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+    }
+    response = get_detailed_response(params)
+
+    assert response.status_code == 200
+
 
 def test_detailed_point_validity():
     min_lat = GLOFAS_ROI["min_lat"]

--- a/flood_api/tests/test_detailed.py
+++ b/flood_api/tests/test_detailed.py
@@ -10,6 +10,8 @@ from flood_api.settings import settings
 from flood_api.tests.synthetic_data import gdf_test_detailed
 
 GLOFAS_ROI = settings.glofas_roi
+OUT_OF_BOUNDS_STATUS_CODE = settings.out_of_bounds_query_status_code
+INVALID_STATUS_CODE = settings.invalid_query_status_code
 
 TOTAL_STEPS = 30
 
@@ -27,13 +29,11 @@ def get_detailed_response_code(params):
 
 
 def test_detailed_arg_validity():
-    expected_error_code = 404
-
     # Neither lat/lon nor bbox are provided
     params = {"include_neighbors": "true"}
     response = get_detailed_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # Both lat/lon and bbox are provided
     params = {
@@ -46,7 +46,7 @@ def test_detailed_arg_validity():
     }
     response = get_detailed_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # Incomplete bbox is provided
     params = {
@@ -56,7 +56,7 @@ def test_detailed_arg_validity():
     }
     response = get_detailed_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # Incomplete coordinates are provided
     params = {
@@ -64,7 +64,7 @@ def test_detailed_arg_validity():
     }
     response = get_detailed_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # One of the coordinates is zero
     params = {
@@ -93,27 +93,26 @@ def test_detailed_point_validity():
     min_lon = GLOFAS_ROI["min_lon"]
     max_lon = GLOFAS_ROI["max_lon"]
     eps = 1e-6
-    expected_error_code = 404
 
     # Queried latitude is outside the ROI
     params = {"lat": min_lat - eps, "lon": (min_lon + max_lon) / 2}
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried latitude is outside the ROI
     # Being on the upper boundary implies
     # that the queried point is outside the ROI
     params = {"lat": max_lat, "lon": (min_lon + max_lon) / 2}
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried longitude is outside the ROI
     params = {"lat": (min_lat + max_lat) / 2, "lon": min_lon - eps}
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried longitude is outside the ROI
     # Being on the upper boundary implies
     # that the queried point is outside the ROI
     params = {"lat": (min_lat + max_lat) / 2, "lon": max_lon}
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried point is within the ROI
     # Being on the lower boundary implies
@@ -134,7 +133,6 @@ def test_detailed_bbox_validity():
     min_lon = GLOFAS_ROI["min_lon"]
     max_lon = GLOFAS_ROI["max_lon"]
     eps = 1e-6
-    expected_error_code = 404
 
     # Queried maximum latitude is smaller than the minimum latitude
     params = {
@@ -143,7 +141,7 @@ def test_detailed_bbox_validity():
         "min_lon": 0.0,
         "max_lon": 10.0,
     }
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == INVALID_STATUS_CODE
 
     # Queried maximum longitude is the same as the minimum longitude
     params = {
@@ -152,7 +150,7 @@ def test_detailed_bbox_validity():
         "min_lon": 4.0,
         "max_lon": 4.0,
     }
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == INVALID_STATUS_CODE
 
     # Queried minimum latitude is outside the ROI
     params = {
@@ -161,7 +159,7 @@ def test_detailed_bbox_validity():
         "min_lon": (min_lon + max_lon) / 4,
         "max_lon": (min_lon + max_lon) / 2,
     }
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried maximum latitude is outside the ROI
     params = {
@@ -170,7 +168,7 @@ def test_detailed_bbox_validity():
         "min_lon": (min_lon + max_lon) / 4,
         "max_lon": (min_lon + max_lon) / 2,
     }
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried minimum longitude is outside the ROI
     params = {
@@ -179,7 +177,7 @@ def test_detailed_bbox_validity():
         "min_lon": min_lon - eps,
         "max_lon": (min_lon + max_lon) / 2,
     }
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried maximum longitude is outside the ROI
     params = {
@@ -188,7 +186,7 @@ def test_detailed_bbox_validity():
         "min_lon": (min_lon + max_lon) / 2,
         "max_lon": max_lon + eps,
     }
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried minimum latitude is inside the ROI
     params = {
@@ -264,7 +262,6 @@ def test_detailed_point_date_range():
     max_lat = GLOFAS_ROI["max_lat"]
     min_lon = GLOFAS_ROI["min_lon"]
     max_lon = GLOFAS_ROI["max_lon"]
-    expected_error_code = 404
 
     # Start date is before the end date
     params = {
@@ -284,7 +281,7 @@ def test_detailed_point_date_range():
         "end_date": "2023-11-28",
     }
 
-    assert get_detailed_response_code(params) == expected_error_code
+    assert get_detailed_response_code(params) == INVALID_STATUS_CODE
 
     # Start date and end date are the same
     params = {

--- a/flood_api/tests/test_detailed.py
+++ b/flood_api/tests/test_detailed.py
@@ -218,7 +218,7 @@ def test_detailed_point_border_query():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -233,7 +233,7 @@ def test_detailed_point_border_query():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is empty
     assert gdf.empty
@@ -289,7 +289,7 @@ def test_detailed_point_general():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -315,7 +315,9 @@ def test_detailed_point_neighbor():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf_neighbor = gpd.GeoDataFrame.from_features(data["neighboring_data"]["features"])
+    gdf_neighbor = gpd.GeoDataFrame.from_features(
+        data["neighboring_location"]["features"]
+    )
 
     # Assert that dataframe is not empty
     assert not gdf_neighbor.empty
@@ -347,8 +349,10 @@ def test_detailed_point_day_range():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
-    gdf_neighbor = gpd.GeoDataFrame.from_features(data["neighboring_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
+    gdf_neighbor = gpd.GeoDataFrame.from_features(
+        data["neighboring_location"]["features"]
+    )
 
     # Convert 'valid_for' column to date
     gdf["valid_for"] = pd.to_datetime(gdf["valid_for"]).dt.date
@@ -393,7 +397,7 @@ def test_detailed_point_day_range_no_start():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Convert 'valid_for' column to date
     gdf["valid_for"] = pd.to_datetime(gdf["valid_for"]).dt.date
@@ -429,7 +433,7 @@ def test_detailed_point_day_range_no_end():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Convert 'valid_for' column to date
     gdf["valid_for"] = pd.to_datetime(gdf["valid_for"]).dt.date
@@ -466,7 +470,7 @@ def test_detailed_bbox_general():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -491,7 +495,7 @@ def test_detailed_bbox_general():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty

--- a/flood_api/tests/test_summary.py
+++ b/flood_api/tests/test_summary.py
@@ -13,12 +13,56 @@ app.dependency_overrides[get_summary_data] = lambda: gdf_test_summary
 client = TestClient(app)
 
 
+def get_summary_response(params):
+    return client.get("/summary", params=params)
+
+
 def get_summary_response_code(params):
-    response = client.get("/summary", params=params)
-    return response.status_code
+    return get_summary_response(params).status_code
 
 
-def test_summary_roi():
+def test_summary_arg_validity():
+    expected_error_code = 404
+
+    # Neither lat/lon nor bbox are provided
+    params = {"include_neighbors": "true"}
+    response = get_summary_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Both lat/lon and bbox are provided
+    params = {
+        "lat": 6.2,
+        "lon": 39.05,
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+    response = get_summary_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Incomplete bbox is provided
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+        "min_lon": 39.0,
+    }
+    response = get_summary_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Incomplete coordinates are provided
+    params = {
+        "lat": 6.2,
+    }
+    response = get_summary_response(params)
+
+    assert response.status_code == expected_error_code
+
+
+def test_summary_point_validity():
     min_lat = GLOFAS_ROI["min_lat"]
     max_lat = GLOFAS_ROI["max_lat"]
     min_lon = GLOFAS_ROI["min_lon"]
@@ -59,18 +103,117 @@ def test_summary_roi():
     assert get_summary_response_code(params) == 200
 
 
-def test_summary_border_query():
+def test_summary_bbox_validity():
+    min_lat = GLOFAS_ROI["min_lat"]
+    max_lat = GLOFAS_ROI["max_lat"]
+    min_lon = GLOFAS_ROI["min_lon"]
+    max_lon = GLOFAS_ROI["max_lon"]
+    eps = 1e-6
+    expected_error_code = 404
+
+    # Queried maximum latitude is smaller than the minimum latitude
+    params = {
+        "min_lat": 4.0,
+        "max_lat": 3.0,
+        "min_lon": 0.0,
+        "max_lon": 10.0,
+    }
+    assert get_summary_response_code(params) == expected_error_code
+
+    # Queried maximum longitude is the same as the minimum longitude
+    params = {
+        "min_lat": 0.0,
+        "max_lat": 10.0,
+        "min_lon": 4.0,
+        "max_lon": 4.0,
+    }
+    assert get_summary_response_code(params) == expected_error_code
+
+    # Queried minimum latitude is outside the ROI
+    params = {
+        "min_lat": min_lat - eps,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_summary_response_code(params) == expected_error_code
+
+    # Queried maximum latitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 2,
+        "max_lat": max_lat + eps,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_summary_response_code(params) == expected_error_code
+
+    # Queried minimum longitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": min_lon - eps,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_summary_response_code(params) == expected_error_code
+
+    # Queried maximum longitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 2,
+        "max_lon": max_lon + eps,
+    }
+    assert get_summary_response_code(params) == expected_error_code
+
+    # Queried minimum latitude is inside the ROI
+    params = {
+        "min_lat": min_lat,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_summary_response_code(params) == 200
+
+    # Queried maximum latitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 2,
+        "max_lat": max_lat,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_summary_response_code(params) == 200
+
+    # Queried minimum longitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": min_lon,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_summary_response_code(params) == 200
+
+    # Queried maximum longitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 2,
+        "max_lon": max_lon,
+    }
+    assert get_summary_response_code(params) == 200
+
+
+def test_summary_point_border_query():
     # Queried point is in the lower left
     # corner of the grid cell
     params = {"lat": 6.2, "lon": 39.05}
 
-    response = client.get("/summary", params=params)
+    response = get_summary_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -79,31 +222,75 @@ def test_summary_border_query():
     # corner of the grid cell
     params = {"lat": 6.2, "lon": 39.1}
 
-    response = client.get("/summary", params=params)
+    response = get_summary_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Assert that dataframe is empty
     assert gdf.empty
 
 
-def test_summary_neighbor():
+def test_summary_point_neighbor():
     # Neighboring cells are included
     params = {"lat": 6.2, "lon": 39.05, "include_neighbors": "true"}
 
-    response = client.get("/summary", params=params)
+    response = get_summary_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf_neighbors = gpd.GeoDataFrame.from_features(
-        data["neighboring_cells"]["features"]
-    )
+    gdf_neighbors = gpd.GeoDataFrame.from_features(data["neighboring_data"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf_neighbors.empty
+
+
+def test_summary_bbox_general():
+    # Queried bounding box covers both cells in the test data
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.25,  # On the boundary between the two cells
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+
+    response = get_summary_response(params)
+    data = response.json()
+
+    assert response.status_code == 200
+
+    # Convert the dictionary to a GeoDataFrame
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+
+    # Assert that dataframe is not empty
+    assert not gdf.empty
+
+    # Assert that row count is correct
+    assert len(gdf) == 2
+
+    # Queried bounding box covers only one cell in the test data
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.24999,  # Just below the upper boundary
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+
+    response = get_summary_response(params)
+    data = response.json()
+
+    assert response.status_code == 200
+
+    # Convert the dictionary to a GeoDataFrame
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+
+    # Assert that dataframe is not empty
+    assert not gdf.empty
+
+    # Assert that row count is correct
+    assert len(gdf) == 1

--- a/flood_api/tests/test_summary.py
+++ b/flood_api/tests/test_summary.py
@@ -7,8 +7,8 @@ from flood_api.settings import settings
 from flood_api.tests.synthetic_data import gdf_test_summary
 
 GLOFAS_ROI = settings.glofas_roi
-OUT_OF_BOUNDS_STATUS_CODE = settings.out_of_bounds_query_status_code
-INVALID_STATUS_CODE = settings.invalid_query_status_code
+OUT_OF_BOUNDS_STATUS_CODE = 404
+INVALID_STATUS_CODE = 400
 
 app.dependency_overrides[get_summary_data] = lambda: gdf_test_summary
 

--- a/flood_api/tests/test_summary.py
+++ b/flood_api/tests/test_summary.py
@@ -213,7 +213,7 @@ def test_summary_point_border_query():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -228,7 +228,7 @@ def test_summary_point_border_query():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is empty
     assert gdf.empty
@@ -244,7 +244,9 @@ def test_summary_point_neighbor():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf_neighbors = gpd.GeoDataFrame.from_features(data["neighboring_data"]["features"])
+    gdf_neighbors = gpd.GeoDataFrame.from_features(
+        data["neighboring_location"]["features"]
+    )
 
     # Assert that dataframe is not empty
     assert not gdf_neighbors.empty
@@ -265,7 +267,7 @@ def test_summary_bbox_general():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -287,7 +289,7 @@ def test_summary_bbox_general():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty

--- a/flood_api/tests/test_summary.py
+++ b/flood_api/tests/test_summary.py
@@ -7,6 +7,8 @@ from flood_api.settings import settings
 from flood_api.tests.synthetic_data import gdf_test_summary
 
 GLOFAS_ROI = settings.glofas_roi
+OUT_OF_BOUNDS_STATUS_CODE = settings.out_of_bounds_query_status_code
+INVALID_STATUS_CODE = settings.invalid_query_status_code
 
 app.dependency_overrides[get_summary_data] = lambda: gdf_test_summary
 
@@ -22,13 +24,11 @@ def get_summary_response_code(params):
 
 
 def test_summary_arg_validity():
-    expected_error_code = 404
-
     # Neither lat/lon nor bbox are provided
     params = {"include_neighbors": "true"}
     response = get_summary_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # Both lat/lon and bbox are provided
     params = {
@@ -41,7 +41,7 @@ def test_summary_arg_validity():
     }
     response = get_summary_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # Incomplete bbox is provided
     params = {
@@ -51,7 +51,7 @@ def test_summary_arg_validity():
     }
     response = get_summary_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # Incomplete coordinates are provided
     params = {
@@ -59,7 +59,7 @@ def test_summary_arg_validity():
     }
     response = get_summary_response(params)
 
-    assert response.status_code == expected_error_code
+    assert response.status_code == INVALID_STATUS_CODE
 
     # One of the coordinates is zero
     params = {
@@ -88,27 +88,26 @@ def test_summary_point_validity():
     min_lon = GLOFAS_ROI["min_lon"]
     max_lon = GLOFAS_ROI["max_lon"]
     eps = 1e-6
-    expected_error_code = 404
 
     # Queried latitude is outside the ROI
     params = {"lat": min_lat - eps, "lon": (min_lon + max_lon) / 2}
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried latitude is outside the ROI
     # Being on the upper boundary implies
     # that the queried point is outside the ROI
     params = {"lat": max_lat, "lon": (min_lon + max_lon) / 2}
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried longitude is outside the ROI
     params = {"lat": (min_lat + max_lat) / 2, "lon": min_lon - eps}
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried longitude is outside the ROI
     # Being on the upper boundary implies
     # that the queried point is outside the ROI
     params = {"lat": (min_lat + max_lat) / 2, "lon": max_lon}
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried point is within the ROI
     # Being on the lower boundary implies
@@ -129,7 +128,6 @@ def test_summary_bbox_validity():
     min_lon = GLOFAS_ROI["min_lon"]
     max_lon = GLOFAS_ROI["max_lon"]
     eps = 1e-6
-    expected_error_code = 404
 
     # Queried maximum latitude is smaller than the minimum latitude
     params = {
@@ -138,7 +136,7 @@ def test_summary_bbox_validity():
         "min_lon": 0.0,
         "max_lon": 10.0,
     }
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == INVALID_STATUS_CODE
 
     # Queried maximum longitude is the same as the minimum longitude
     params = {
@@ -147,7 +145,7 @@ def test_summary_bbox_validity():
         "min_lon": 4.0,
         "max_lon": 4.0,
     }
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == INVALID_STATUS_CODE
 
     # Queried minimum latitude is outside the ROI
     params = {
@@ -156,7 +154,7 @@ def test_summary_bbox_validity():
         "min_lon": (min_lon + max_lon) / 4,
         "max_lon": (min_lon + max_lon) / 2,
     }
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried maximum latitude is outside the ROI
     params = {
@@ -165,7 +163,7 @@ def test_summary_bbox_validity():
         "min_lon": (min_lon + max_lon) / 4,
         "max_lon": (min_lon + max_lon) / 2,
     }
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried minimum longitude is outside the ROI
     params = {
@@ -174,7 +172,7 @@ def test_summary_bbox_validity():
         "min_lon": min_lon - eps,
         "max_lon": (min_lon + max_lon) / 2,
     }
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried maximum longitude is outside the ROI
     params = {
@@ -183,7 +181,7 @@ def test_summary_bbox_validity():
         "min_lon": (min_lon + max_lon) / 2,
         "max_lon": max_lon + eps,
     }
-    assert get_summary_response_code(params) == expected_error_code
+    assert get_summary_response_code(params) == OUT_OF_BOUNDS_STATUS_CODE
 
     # Queried minimum latitude is inside the ROI
     params = {

--- a/flood_api/tests/test_summary.py
+++ b/flood_api/tests/test_summary.py
@@ -61,6 +61,26 @@ def test_summary_arg_validity():
 
     assert response.status_code == expected_error_code
 
+    # One of the coordinates is zero
+    params = {
+        "lon": 0.0,
+        "lat": 6.2,
+    }
+    response = get_summary_response(params)
+
+    assert response.status_code == 200
+
+    # One of the bounding box coordinates is zero
+    params = {
+        "min_lon": 0.0,
+        "max_lon": 40.0,
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+    }
+    response = get_summary_response(params)
+
+    assert response.status_code == 200
+
 
 def test_summary_point_validity():
     min_lat = GLOFAS_ROI["min_lat"]

--- a/flood_api/tests/test_threshold.py
+++ b/flood_api/tests/test_threshold.py
@@ -13,12 +13,56 @@ app.dependency_overrides[get_threshold_data] = lambda: gdf_test_threshold
 client = TestClient(app)
 
 
+def get_threshold_response(params):
+    return client.get("/threshold", params=params)
+
+
 def get_threshold_response_code(params):
-    response = client.get("/threshold", params=params)
-    return response.status_code
+    return get_threshold_response(params).status_code
 
 
-def test_threshold_roi():
+def test_threshold_arg_validity():
+    expected_error_code = 404
+
+    # Neither lat/lon nor bbox are provided
+    params = {"include_neighbors": "true"}
+    response = get_threshold_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Both lat/lon and bbox are provided
+    params = {
+        "lat": 6.2,
+        "lon": 39.05,
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+    response = get_threshold_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Incomplete bbox is provided
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+        "min_lon": 39.0,
+    }
+    response = get_threshold_response(params)
+
+    assert response.status_code == expected_error_code
+
+    # Incomplete coordinates are provided
+    params = {
+        "lat": 6.2,
+    }
+    response = get_threshold_response(params)
+
+    assert response.status_code == expected_error_code
+
+
+def test_threshold_point_validity():
     min_lat = GLOFAS_ROI["min_lat"]
     max_lat = GLOFAS_ROI["max_lat"]
     min_lon = GLOFAS_ROI["min_lon"]
@@ -59,18 +103,117 @@ def test_threshold_roi():
     assert get_threshold_response_code(params) == 200
 
 
+def test_threshold_bbox_validity():
+    min_lat = GLOFAS_ROI["min_lat"]
+    max_lat = GLOFAS_ROI["max_lat"]
+    min_lon = GLOFAS_ROI["min_lon"]
+    max_lon = GLOFAS_ROI["max_lon"]
+    eps = 1e-6
+    expected_error_code = 404
+
+    # Queried maximum latitude is smaller than the minimum latitude
+    params = {
+        "min_lat": 4.0,
+        "max_lat": 3.0,
+        "min_lon": 0.0,
+        "max_lon": 10.0,
+    }
+    assert get_threshold_response_code(params) == expected_error_code
+
+    # Queried maximum longitude is the same as the minimum longitude
+    params = {
+        "min_lat": 0.0,
+        "max_lat": 10.0,
+        "min_lon": 4.0,
+        "max_lon": 4.0,
+    }
+    assert get_threshold_response_code(params) == expected_error_code
+
+    # Queried minimum latitude is outside the ROI
+    params = {
+        "min_lat": min_lat - eps,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_threshold_response_code(params) == expected_error_code
+
+    # Queried maximum latitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 2,
+        "max_lat": max_lat + eps,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_threshold_response_code(params) == expected_error_code
+
+    # Queried minimum longitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": min_lon - eps,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_threshold_response_code(params) == expected_error_code
+
+    # Queried maximum longitude is outside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 2,
+        "max_lon": max_lon + eps,
+    }
+    assert get_threshold_response_code(params) == expected_error_code
+
+    # Queried minimum latitude is inside the ROI
+    params = {
+        "min_lat": min_lat,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_threshold_response_code(params) == 200
+
+    # Queried maximum latitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 2,
+        "max_lat": max_lat,
+        "min_lon": (min_lon + max_lon) / 4,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_threshold_response_code(params) == 200
+
+    # Queried minimum longitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": min_lon,
+        "max_lon": (min_lon + max_lon) / 2,
+    }
+    assert get_threshold_response_code(params) == 200
+
+    # Queried maximum longitude is inside the ROI
+    params = {
+        "min_lat": (min_lat + max_lat) / 4,
+        "max_lat": (min_lat + max_lat) / 2,
+        "min_lon": (min_lon + max_lon) / 2,
+        "max_lon": max_lon,
+    }
+    assert get_threshold_response_code(params) == 200
+
+
 def test_threshold_border_query():
     # Queried point is in the lower left
     # corner of the grid cell
     params = {"lat": 6.2, "lon": 39.05}
 
-    response = client.get("/threshold", params=params)
+    response = get_threshold_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -79,13 +222,59 @@ def test_threshold_border_query():
     # corner of the grid cell
     params = {"lat": 6.2, "lon": 39.1}
 
-    response = client.get("/threshold", params=params)
+    response = get_threshold_response(params)
     data = response.json()
 
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_cell"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
 
     # Assert that dataframe is empty
     assert gdf.empty
+
+
+def test_summary_bbox_general():
+    # Queried bounding box covers both cells in the test data
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.25,  # On the boundary between the two cells
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+
+    response = get_threshold_response(params)
+    data = response.json()
+
+    assert response.status_code == 200
+
+    # Convert the dictionary to a GeoDataFrame
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+
+    # Assert that dataframe is not empty
+    assert not gdf.empty
+
+    # Assert that row count is correct
+    assert len(gdf) == 2
+
+    # Queried bounding box covers only one cell in the test data
+    params = {
+        "min_lat": 6.225,
+        "max_lat": 6.24999,  # Just below the upper boundary
+        "min_lon": 39.0,
+        "max_lon": 40.0,
+    }
+
+    response = get_threshold_response(params)
+    data = response.json()
+
+    assert response.status_code == 200
+
+    # Convert the dictionary to a GeoDataFrame
+    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+
+    # Assert that dataframe is not empty
+    assert not gdf.empty
+
+    # Assert that row count is correct
+    assert len(gdf) == 1

--- a/flood_api/tests/test_threshold.py
+++ b/flood_api/tests/test_threshold.py
@@ -61,6 +61,26 @@ def test_threshold_arg_validity():
 
     assert response.status_code == expected_error_code
 
+    # One of the coordinates is zero
+    params = {
+        "lon": 0.0,
+        "lat": 6.2,
+    }
+    response = get_threshold_response(params)
+
+    assert response.status_code == 200
+
+    # One of the bounding box coordinates is zero
+    params = {
+        "min_lon": 0.0,
+        "max_lon": 40.0,
+        "min_lat": 6.225,
+        "max_lat": 6.25,
+    }
+    response = get_threshold_response(params)
+
+    assert response.status_code == 200
+
 
 def test_threshold_point_validity():
     min_lat = GLOFAS_ROI["min_lat"]

--- a/flood_api/tests/test_threshold.py
+++ b/flood_api/tests/test_threshold.py
@@ -213,7 +213,7 @@ def test_threshold_border_query():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -228,7 +228,7 @@ def test_threshold_border_query():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is empty
     assert gdf.empty
@@ -249,7 +249,7 @@ def test_summary_bbox_general():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty
@@ -271,7 +271,7 @@ def test_summary_bbox_general():
     assert response.status_code == 200
 
     # Convert the dictionary to a GeoDataFrame
-    gdf = gpd.GeoDataFrame.from_features(data["queried_data"]["features"])
+    gdf = gpd.GeoDataFrame.from_features(data["queried_location"]["features"])
 
     # Assert that dataframe is not empty
     assert not gdf.empty

--- a/flood_api/tests/test_threshold.py
+++ b/flood_api/tests/test_threshold.py
@@ -7,8 +7,8 @@ from flood_api.settings import settings
 from flood_api.tests.synthetic_data import gdf_test_threshold
 
 GLOFAS_ROI = settings.glofas_roi
-OUT_OF_BOUNDS_STATUS_CODE = settings.out_of_bounds_query_status_code
-INVALID_STATUS_CODE = settings.invalid_query_status_code
+OUT_OF_BOUNDS_STATUS_CODE = 404
+INVALID_STATUS_CODE = 400
 
 app.dependency_overrides[get_threshold_data] = lambda: gdf_test_threshold
 

--- a/flood_api/utils/geospatial_operations.py
+++ b/flood_api/utils/geospatial_operations.py
@@ -109,8 +109,8 @@ def create_polygon_from_bounds(
 def get_data_for_roi(
     roi: Polygon,
     gdf: gpd.GeoDataFrame,
-    date_range: tuple[date, date] = None,
-    expanded_roi: Polygon = None,
+    date_range: tuple[date, date] | None = None,
+    expanded_roi: Polygon | None = None,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
     Given a region of interest, return the data for the grid cells
@@ -162,7 +162,7 @@ def get_data_for_point(
     longitude: float,
     gdf: gpd.GeoDataFrame,
     include_neighbors: bool = False,
-    date_range: tuple[date, date] = None,
+    date_range: tuple[date, date] | None = None,
 ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
     Given a latitude and longitude, return the data for the grid cell
@@ -223,7 +223,7 @@ def get_data_for_point(
 def get_data_for_bbox(
     bbox: tuple[float, float, float, float],
     gdf: gpd.GeoDataFrame,
-    date_range: tuple[date, date] = None,
+    date_range: tuple[date, date] | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Given a bounding box, return the data for the grid cells

--- a/flood_api/utils/json_utilities.py
+++ b/flood_api/utils/json_utilities.py
@@ -21,7 +21,7 @@ def custom_date_handler(obj: object) -> str:
 
 
 def dataframe_to_geojson(
-    df: gpd.GeoDataFrame, columns: list[str], sort_columns: list[str] = None
+    df: gpd.GeoDataFrame, columns: list[str], sort_columns: list[str] | None = None
 ) -> dict:
     """
     Convert a GeoDataFrame to a GeoJSON.

--- a/flood_api/utils/validation_helpers.py
+++ b/flood_api/utils/validation_helpers.py
@@ -5,8 +5,6 @@ from fastapi import HTTPException
 from flood_api.settings import settings
 
 GLOFAS_ROI = settings.glofas_roi
-OUT_OF_BOUNDS_STATUS_CODE = settings.out_of_bounds_query_status_code
-INVALID_STATUS_CODE = settings.invalid_query_status_code
 
 
 def validate_coordinates(latitude: float, longitude: float) -> None:
@@ -28,7 +26,7 @@ def validate_coordinates(latitude: float, longitude: float) -> None:
 
     if not point_within_roi:
         raise HTTPException(
-            status_code=OUT_OF_BOUNDS_STATUS_CODE,
+            status_code=404,
             detail="Queried coordinates are outside the region of interest",
         )
 
@@ -58,7 +56,7 @@ def validate_bounding_box(
 
     if not bounding_box_is_valid:
         raise HTTPException(
-            status_code=INVALID_STATUS_CODE,
+            status_code=400,
             detail="Invalid bounding box",
         )
 
@@ -69,7 +67,7 @@ def validate_bounding_box(
 
     if not bounding_box_within_roi:
         raise HTTPException(
-            status_code=OUT_OF_BOUNDS_STATUS_CODE,
+            status_code=404,
             detail="Queried bounding box is not within the region of interest",
         )
 
@@ -89,6 +87,4 @@ def validate_dates(start_date: date, end_date: date) -> None:
     date_range_is_valid = start_date <= end_date
 
     if not date_range_is_valid:
-        raise HTTPException(
-            status_code=INVALID_STATUS_CODE, detail="Invalid date range"
-        )
+        raise HTTPException(status_code=400, detail="Invalid date range")

--- a/flood_api/utils/validation_helpers.py
+++ b/flood_api/utils/validation_helpers.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 from flood_api.settings import settings
 
 GLOFAS_ROI = settings.glofas_roi
+INVALID_STATUS_CODE = 404
 
 
 def validate_coordinates(latitude: float, longitude: float) -> None:
@@ -26,8 +27,47 @@ def validate_coordinates(latitude: float, longitude: float) -> None:
 
     if not point_within_roi:
         raise HTTPException(
-            status_code=404,
+            status_code=INVALID_STATUS_CODE,
             detail="Queried coordinates are outside the region of interest",
+        )
+
+
+def validate_bounding_box(
+    min_lat: float,
+    max_lat: float,
+    min_lon: float,
+    max_lon: float,
+) -> None:
+    """
+    Check if the given bounding box is within the region of interest (ROI).
+    If not, raise an HTTPException with status code 404.
+
+    Parameters:
+    - min_lat (float): The minimum latitude of the bounding box.
+    - max_lat (float): The maximum latitude of the bounding box.
+    - min_lon (float): The minimum longitude of the bounding box.
+    - max_lon (float): The maximum longitude of the bounding box.
+
+    Returns:
+    None
+    """
+    bounding_box_is_valid = min_lat < max_lat and min_lon < max_lon
+
+    if not bounding_box_is_valid:
+        raise HTTPException(
+            status_code=INVALID_STATUS_CODE,
+            detail="Invalid bounding box",
+        )
+
+    bounding_box_within_roi = (
+        GLOFAS_ROI["min_lat"] <= min_lat < max_lat <= GLOFAS_ROI["max_lat"]
+        and GLOFAS_ROI["min_lon"] <= min_lon < max_lon <= GLOFAS_ROI["max_lon"]
+    )
+
+    if not bounding_box_within_roi:
+        raise HTTPException(
+            status_code=INVALID_STATUS_CODE,
+            detail="Queried bounding box is outside the region of interest",
         )
 
 
@@ -43,7 +83,43 @@ def validate_dates(start_date: date, end_date: date) -> None:
     Returns:
     None
     """
-    date_range_valid = start_date <= end_date
+    date_range_is_valid = start_date <= end_date
 
-    if not date_range_valid:
-        raise HTTPException(status_code=400, detail="Invalid date range")
+    if not date_range_is_valid:
+        raise HTTPException(
+            status_code=INVALID_STATUS_CODE, detail="Invalid date range"
+        )
+
+
+def validate_generic_inputs(*args: tuple, possible_inputs_str: str) -> None:
+    """
+    Check if exaclty one of the given inputs is valid, i.e. not None.
+    If not, raise an HTTPException with status code 404.
+
+    Parameters:
+    - args (tuple): The inputs to check.
+    - possible_inputs_str (str): A string listing the possible inputs.
+
+    Returns:
+    None
+    """
+    valid_inputs_count = sum(map(bool, args))
+
+    # Determine the appropriate error message
+    if valid_inputs_count == 0:
+        error_message = (
+            "One of the following inputs must be provided: " + possible_inputs_str
+        )
+    elif valid_inputs_count > 1:
+        error_message = (
+            "Only one of the following inputs can be provided: " + possible_inputs_str
+        )
+    else:
+        # If there is exactly one valid input, return without raising an exception
+        return
+
+    # Raise an HTTPException with the determined error message
+    raise HTTPException(
+        status_code=INVALID_STATUS_CODE,
+        detail=error_message,
+    )

--- a/flood_api/utils/validation_helpers.py
+++ b/flood_api/utils/validation_helpers.py
@@ -67,7 +67,7 @@ def validate_bounding_box(
     if not bounding_box_within_roi:
         raise HTTPException(
             status_code=INVALID_STATUS_CODE,
-            detail="Queried bounding box is outside the region of interest",
+            detail="Queried bounding box is not within the region of interest",
         )
 
 


### PR DESCRIPTION
Adds bounding box querying to the `summary`, `detailed`, and `threshold` endpoints. A bounding box is defined by the `min_lat`, `max_lat`, `min_lon`, and `max_lon` attributes. 

The endpoints can either be fed `lat` and `lon` to query a single point (as before) or the bbox attributes to query a larger area. Only one of these options should be used at a time, and a 404 error is returned if both a point and a bbox are queried (or neither).

In the future, since the underlying dataframes are queried using `Polygon` and the `intersects` operation, an additional querying parameter `roi` could be added to take an arbitrary polygon shape as input to the API (e.g., in [WKT](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry) representation).