### PR TITLE
fix: add CORS middleware

### DIFF
--- a/deployment/kubernetes/flood-api.yaml
+++ b/deployment/kubernetes/flood-api.yaml
@@ -61,6 +61,19 @@ spec:
     forceSlash: true
 ---
 apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: cors-flood
+spec:
+  headers:
+    accessControlAllowMethods:
+      - "GET"
+    accessControlAllowHeaders:
+      - "*"
+    accessControlAllowOriginList:
+      - "*"
+---
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: flood-api
@@ -76,3 +89,4 @@ spec:
       port: 80
     middlewares:
     - name: stripprefix-flood
+    - name: cors-flood 


### PR DESCRIPTION
Adds a middleware for CORS handling. This allows webpages to make requests without having a server.